### PR TITLE
Add Mac support to salt generation command

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -103,7 +103,7 @@ $config = array(
      * 'secretsalt' can be any valid string of any length.
      *
      * A possible way to generate a random salt is by running the following command from a unix shell:
-     * tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
+     * LC_CTYPE=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
      */
     'secretsalt' => 'defaultsecretsalt',
 


### PR DESCRIPTION
Without setting `LC_CTYPE=C` on a Mac, the salt generation command throws an "Illegal byte sequence" error (most probably the `tr` command thinks the input is invalid UTF-8, which might be correct). This PR fixes this problem, and it should not cause any harm on other systems as the C locale should be available just about everywhere.